### PR TITLE
Add SBT multi-project support, fixes #4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,11 +27,8 @@ scalaVersion := "2.10.4"
 scalacOptions ++= Seq(
   "-deprecation",
   "-unchecked",
-  "-encoding", "UTF-8",
-  "-target:jvm-1.7"
+  "-encoding", "UTF-8"
 )
-
-javacOptions ++= Seq("-source", "1.7")
 
 /* publishing */
 publishMavenStyle := true

--- a/build.sbt
+++ b/build.sbt
@@ -27,8 +27,11 @@ scalaVersion := "2.10.4"
 scalacOptions ++= Seq(
   "-deprecation",
   "-unchecked",
-  "-encoding", "UTF-8"
+  "-encoding", "UTF-8",
+  "-target:jvm-1.7"
 )
+
+javacOptions ++= Seq("-source", "1.7")
 
 /* publishing */
 publishMavenStyle := true

--- a/src/main/scala/net/ceedubs/sbtctags/SbtCtags.scala
+++ b/src/main/scala/net/ceedubs/sbtctags/SbtCtags.scala
@@ -1,8 +1,9 @@
 package net.ceedubs.sbtctags
 
+import java.io.File
+
 import sbt._
 import sbt.std.TaskStreams
-import java.io.File
 
 final case class CtagsGenerationContext(
   ctagsParams: CtagsParams,
@@ -30,47 +31,47 @@ object CtagsKeys {
 object SbtCtags extends Plugin {
 
   override val projectSettings = Seq(
-      CtagsKeys.dependencySrcUnzipDir <<= Keys.target (_ / "sbt-ctags-dep-srcs"),
+    CtagsKeys.dependencySrcUnzipDir <<= Keys.target(_ / "sbt-ctags-dep-srcs"),
 
-      CtagsKeys.ctagsParams in ThisBuild := defaultCtagsParams,
+    CtagsKeys.ctagsParams in ThisBuild := defaultCtagsParams,
 
-      CtagsKeys.ctagsSrcFileFilter <<= CtagsKeys.ctagsParams(_.languages.foldLeft(NameFilter.fnToNameFilter(_ => false))((filter, lang) => filter | GlobFilter(s"*.$lang"))),
+    CtagsKeys.ctagsSrcFileFilter <<= CtagsKeys.ctagsParams(_.languages.foldLeft(NameFilter.fnToNameFilter(_ => false))((filter, lang) => filter | GlobFilter(s"*.$lang"))),
 
-      CtagsKeys.ctagsSrcDirs <<= (Keys.scalaSource in Compile, Keys.scalaSource in Test, Keys.javaSource in Compile, Keys.javaSource in Test, CtagsKeys.dependencySrcUnzipDir){ (srcDir, testDir, javaSrcDir, javaTestDir, depSrcDir) =>
-        Seq(srcDir, testDir, javaSrcDir, javaTestDir, depSrcDir)
-      },
+    CtagsKeys.ctagsSrcDirs <<= (Keys.scalaSource in Compile, Keys.scalaSource in Test, Keys.javaSource in Compile, Keys.javaSource in Test, CtagsKeys.dependencySrcUnzipDir) { (srcDir, testDir, javaSrcDir, javaTestDir, depSrcDir) =>
+      Seq(srcDir, testDir, javaSrcDir, javaTestDir, depSrcDir)
+    },
 
-      CtagsKeys.ctagsGeneration in ThisBuild := defaultCtagsGeneration,
+    CtagsKeys.ctagsGeneration in ThisBuild := defaultCtagsGeneration,
 
-      CtagsKeys.genCtags <<= (Keys.state, CtagsKeys.dependencySrcUnzipDir, CtagsKeys.ctagsParams, CtagsKeys.ctagsSrcFileFilter, CtagsKeys.ctagsGeneration, CtagsKeys.ctagsSrcDirs, Keys.streams) map genCtags
-  )
+    CtagsKeys.genCtags <<= (Keys.thisProjectRef, Keys.state, CtagsKeys.dependencySrcUnzipDir, CtagsKeys.ctagsParams, CtagsKeys.ctagsSrcFileFilter, CtagsKeys.ctagsGeneration, CtagsKeys.ctagsSrcDirs, Keys.streams) map genCtags)
 
-  val defaultCtagsParams: CtagsParams = CtagsParams(
-        executable = "ctags",
-        excludes = Seq("log"),
-        languages = Seq("scala", "java"),
-        tagFileName = ".tags",
-        extraArgs = Seq.empty)
+  val defaultCtagsParams = CtagsParams(
+    executable = "ctags",
+    excludes = Seq("log"),
+    languages = Seq("scala", "java"),
+    tagFileName = "tags",
+    extraArgs = Seq.empty)
 
-  def defaultCtagsGeneration(context: CtagsGenerationContext) {
+  def defaultCtagsGeneration(context: CtagsGenerationContext): Unit = {
     val ctagsParams = context.ctagsParams
     val dirArgs = context.srcDirs.map(_.getAbsolutePath).mkString(" ")
     val excludeArgs = ctagsParams.excludes.map(x => s"--exclude=$x").mkString(" ")
     val languagesArgs = if (ctagsParams.languages.isEmpty) "" else s"--languages=${ctagsParams.languages.mkString(",")}"
     val extraArgs = ctagsParams.extraArgs.mkString(" ")
     // will look something like "ctags --exclude=.git --exclude=log --languages=scala -f .tags -R src/main/scala target/sbt-ctags-dep-srcs"
-    val ctagsCmd = s"${ctagsParams.executable} $excludeArgs $languagesArgs -f ${ctagsParams.tagFileName} $extraArgs -R $dirArgs"
+    val ctagsCmd = s"${ctagsParams.executable} $excludeArgs $languagesArgs -a -f ${ctagsParams.tagFileName} $extraArgs -R $dirArgs"
     context.log.info(s"running this command to generate ctags: $ctagsCmd")
     Process(ctagsCmd, Some(new File(context.buildStructure.root)), Seq.empty: _*).!
   }
 
-
-  def genCtags(state: State, dependencySrcUnzipDir: File, ctagsParams: CtagsParams, srcFileFilter: NameFilter, ctagsGeneration: CtagsGenerationContext => Unit, ctagsSrcDirs: Seq[File], streams: TaskStreams[_]) {
+  def genCtags(projectRef: ProjectRef, state: State, dependencySrcUnzipDir: File, ctagsParams: CtagsParams, srcFileFilter: NameFilter, ctagsGeneration: CtagsGenerationContext => Unit, ctagsSrcDirs: Seq[File], streams: TaskStreams[_]): Unit = {
+    // TODO this could be pretty bad if someone overrides the install dir with an important dir
     val extracted = Project.extract(state)
     val buildStruct = extracted.structure
     val log = streams.log
-    log.info(s"Grabbing all dependency source jars. This may take a while if you don't have them in your Ivy cache")
-    EvaluateTask(buildStruct, Keys.updateClassifiers, state, extracted.currentRef).fold(state)(Function.tupled { (state, result) =>
+    val project = Project.getProject(projectRef, buildStruct)
+    log.info(s"Processing project named: ${project.get.id}")
+    EvaluateTask(buildStruct, Keys.updateClassifiers, state, projectRef).fold(state)(Function.tupled { (state, result) =>
       result match {
         case Value(updateReport) =>
           log.info(s"Clearing $dependencySrcUnzipDir")
@@ -88,7 +89,10 @@ object SbtCtags extends Plugin {
           val existingCtagsSrcDirs = ctagsSrcDirs.filter(_.exists)
           log.debug(s"existing ctags src dirs: $existingCtagsSrcDirs")
           log.info(s"Generating tag file")
-          ctagsGeneration(CtagsGenerationContext(ctagsParams, existingCtagsSrcDirs, buildStruct, streams.log))
+
+          val tagPath = s"${project.get.base.getAbsolutePath}/.${ctagsParams.tagFileName}"
+          val projectCtagParams = ctagsParams.copy(tagFileName = tagPath)
+          ctagsGeneration(CtagsGenerationContext(projectCtagParams, existingCtagsSrcDirs, buildStruct, streams.log))
           state
         case x =>
           log.error(s"error trying to update classifiers to find source jars: $x")
@@ -96,5 +100,4 @@ object SbtCtags extends Plugin {
       }
     })
   }
-
 }

--- a/src/main/scala/net/ceedubs/sbtctags/SbtCtags.scala
+++ b/src/main/scala/net/ceedubs/sbtctags/SbtCtags.scala
@@ -59,8 +59,8 @@ object SbtCtags extends Plugin {
     val languagesArgs = if (ctagsParams.languages.isEmpty) "" else s"--languages=${ctagsParams.languages.mkString(",")}"
     val extraArgs = ctagsParams.extraArgs.mkString(" ")
     // will look something like "ctags --exclude=.git --exclude=log --languages=scala -f .tags -R src/main/scala target/sbt-ctags-dep-srcs"
-    val ctagsCmd = s"${ctagsParams.executable} $excludeArgs $languagesArgs -a -f ${ctagsParams.tagFileName} $extraArgs -R $dirArgs"
-    context.log.info(s"running this command to generate ctags: $ctagsCmd")
+    val ctagsCmd = s"${ctagsParams.executable} $excludeArgs $languagesArgs -f ${ctagsParams.tagFileName} $extraArgs -R $dirArgs"
+    context.log.info(s"Running this command to generate ctags: $ctagsCmd")
     Process(ctagsCmd, Some(new File(context.buildStructure.root)), Seq.empty: _*).!
   }
 
@@ -70,6 +70,7 @@ object SbtCtags extends Plugin {
     val buildStruct = extracted.structure
     val log = streams.log
     val project = Project.getProject(projectRef, buildStruct)
+
     log.info(s"Processing project named: ${project.get.id}")
     EvaluateTask(buildStruct, Keys.updateClassifiers, state, projectRef).fold(state)(Function.tupled { (state, result) =>
       result match {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.1.0"
+version in ThisBuild := "0.0.2"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.2"
+version in ThisBuild := "0.2.0"


### PR DESCRIPTION
Continuation of https://github.com/ceedubs/sbt-ctags/pull/7

Tried it on some small repos locally, seems to work. Issue now is if sub-project A depends on B, the generated tags for A doesn't include B so jump-to-definition doesn't like it, though that was discussed in the [original PR](https://github.com/ceedubs/sbt-ctags/pull/7).

> in the worst-case scenario we can throw together a shell script to do aggregation if needed.

If this all looks good, should probably put something in the README describing the behavior.

If we dumped all the tag files in the root project directory w/ different names, it's easier to collect them all using something like [this](http://stackoverflow.com/questions/12916743/include-ctags-files-recursively-from-a-directory), as mentioned in the original PR. I experimented with this a little bit by simply prepending each project's `tag` file with the `id`.

Not sure how good/bad that approach is.
