### PR TITLE
Convert to autoplugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
+import Defaults._
+
 sbtPlugin := true
 
 name := "sbt-ctags"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.0
+sbt.version=0.13.9


### PR DESCRIPTION
Hi again :)
I thought that it could be convenient to migrate the plugin to `AutoPlugin` and here we are... I hope I did it right!
As a result, I bumped `sbt` version to 0.13.9.

Note: I did not change the `sbt` launcher that is included in the project, is it still needed?
