### PR TITLE
Fix signed publishing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,6 +24,8 @@ scmInfo := Some(
 
 scalaVersion := "2.12.5"
 
+sbtVersion in Global := "1.0.3"
+
 crossSbtVersions := Vector("0.13.17", "1.1.0")
 
 scalaCompilerBridgeSource := {
@@ -39,6 +41,11 @@ scalacOptions ++= Seq(
 
 /* publishing */
 publishMavenStyle := true
+
+useGpg := true
+
+// see https://github.com/sbt/sbt-pgp/issues/126
+pgpSecretRing := pgpPublicRing.value
 
 publishTo := {
   val v = version.value

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")


### PR DESCRIPTION
I was using a global version of sbt-pgp earlier. I think that it's
probably better to bring the publishing requirements into this project.
Also I ran into a few issues when trying to publishSigned, and I think
that this PR resolves them.

@sanjivsahayamrea and/or @NightWhistler would you be willing to review this? This is in preparation for (finally) publishing a recent version of the plugin.